### PR TITLE
api를 활용한 Read 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env
+기획.md
+예시.md

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,41 @@
-function App() {
-  return <div className="min-h-screen bg-white"></div>;
-}
+import { useEffect, useState } from 'react';
+import { readBiology, type PokemonBiology } from './api/biology';
+import ListCard from './components/ListCard';
+import BiologyModal from './components/BiologyModal';
 
-export default App;
+export default function App() {
+  const [docs, setDocs] = useState<PokemonBiology[]>([]);
+  const [selected, setSelected] = useState<PokemonBiology | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    readBiology().then(setDocs).finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <div className="p-12 text-center text-slate-400 font-medium">Loading Biology Documents...</div>;
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 font-sans">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {docs.map((doc) => (
+          <ListCard 
+            key={doc.id} 
+            doc={doc} 
+            onClick={setSelected} 
+          />
+        ))}
+      </div>
+
+      {selected && (
+        <BiologyModal 
+          selected={selected} 
+          onClose={() => setSelected(null)} 
+        />
+      )}
+
+      {docs.length === 0 && !loading && (
+        <div className="text-center py-24 text-slate-400 font-medium">데이터가 없습니다.</div>
+      )}
+    </div>
+  );
+}

--- a/src/api/biology.ts
+++ b/src/api/biology.ts
@@ -1,0 +1,49 @@
+import { readIssues, parseBody } from './github';
+import { getImage, type PokemonData } from './pokemon';
+
+export interface PokemonBiology {
+  id: string;
+  pokemon: string;
+  pokemonImage: string;
+  videoTitle: string;
+  videoLink: string;
+  primaryQuestion: string;
+  relatedPokemon: PokemonData[];
+}
+
+export async function readBiology(): Promise<PokemonBiology[]> {
+  const issues = await readIssues();
+
+  const documents = await Promise.all(
+    issues.map(async (issue: any) => {
+      try {
+        const rawDoc = parseBody(issue.body || '');
+
+        const pokemonImage = await getImage(rawDoc.pokemon);
+        const relatedPokemonNames: string[] = rawDoc.relatedPokemon || [];
+        
+        const relatedPokemon = await Promise.all(
+          relatedPokemonNames.map(async (name) => ({
+            name,
+            image: await getImage(name),
+          }))
+        );
+
+        return {
+          id: rawDoc.id,
+          pokemon: rawDoc.pokemon,
+          pokemonImage,
+          videoTitle: rawDoc.videoTitle,
+          videoLink: rawDoc.videoLink || '',
+          primaryQuestion: rawDoc.primaryQuestion,
+          relatedPokemon,
+        };
+      } catch (e) {
+        console.error(`Failed to process issue #${issue.number}`, e);
+        return null;
+      }
+    })
+  );
+
+  return documents.filter((doc): doc is PokemonBiology => doc !== null);
+}

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -1,0 +1,40 @@
+const GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN;
+const GITHUB_OWNER = import.meta.env.VITE_GITHUB_OWNER;
+const GITHUB_REPO = import.meta.env.VITE_GITHUB_REPO;
+
+export async function readIssues() {
+  const response = await fetch(
+    `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues?state=open`,
+    {
+      headers: {
+        Authorization: `token ${GITHUB_TOKEN}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch issues from GitHub");
+  }
+
+  return response.json();
+}
+
+export function parseBody(body: string) {
+  try {
+    const jsonMatch = body.match(/```json\s*([\s\S]*?)\s*```/) || [null, body];
+    let jsonStr = jsonMatch[1].trim();
+
+    const cleanedJson = jsonStr
+      .replace(/,+/g, ",")
+      .replace(/,\s*}/g, "}")
+      .replace(/,\s*\]/g, "]")
+      .replace(/(\r\n|\n|\r)/gm, "")
+      .trim();
+
+    return JSON.parse(cleanedJson);
+  } catch (e) {
+    console.error("JSON Parsing Error:", e);
+    throw new Error("Failed to parse issue body JSON");
+  }
+}

--- a/src/api/pokemon.ts
+++ b/src/api/pokemon.ts
@@ -1,0 +1,32 @@
+export interface PokemonData {
+  name: string;
+  image: string;
+}
+
+const KOREAN_TO_ENGLISH_MAPPING: Record<string, string> = {
+  야돈: "slowpoke",
+  셀러: "shellder",
+  야도란: "slowbro",
+  야도킹: "slowking",
+  피카츄: "pikachu",
+  이브이: "eevee",
+};
+
+export async function getImage(name: string): Promise<string> {
+  try {
+    const englishName = KOREAN_TO_ENGLISH_MAPPING[name] || name;
+    const response = await fetch(
+      `https://pokeapi.co/api/v2/pokemon/${englishName.toLowerCase()}`,
+    );
+    if (!response.ok) return "";
+    const data = await response.json();
+    return (
+      data.sprites.other["official-artwork"].front_default ||
+      data.sprites.front_default ||
+      ""
+    );
+  } catch (e) {
+    console.error(`Failed to fetch PokeAPI for ${name}`, e);
+    return "";
+  }
+}

--- a/src/components/BiologyModal.tsx
+++ b/src/components/BiologyModal.tsx
@@ -1,0 +1,56 @@
+import type { PokemonBiology } from '../api/biology';
+
+interface BiologyModalProps {
+  selected: PokemonBiology;
+  onClose: () => void;
+}
+
+export default function BiologyModal({ selected, onClose }: BiologyModalProps) {
+  return (
+    <div 
+      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50" 
+      onClick={onClose}
+    >
+      <div 
+        className="bg-white p-6 rounded-lg max-w-lg w-full max-h-[90vh] overflow-auto shadow-xl" 
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-start mb-4">
+          <h2 className="text-xl font-bold text-slate-900 leading-snug">{selected.videoTitle}</h2>
+          <button onClick={onClose} className="text-slate-400 text-3xl leading-none px-2 hover:text-slate-600">&times;</button>
+        </div>
+        
+        <img src={selected.pokemonImage} className="w-40 h-40 mx-auto mb-6 object-contain" alt="" />
+        
+        <div className="bg-slate-50 p-4 rounded-md mb-6 border-l-4 border-slate-200">
+          <p className="text-slate-600 italic text-sm leading-relaxed">
+            Q. {selected.primaryQuestion}
+          </p>
+        </div>
+
+        {selected.videoLink && (
+          <a 
+            href={selected.videoLink} 
+            target="_blank" 
+            rel="noopener noreferrer"
+            className="block text-center bg-red-600 text-white py-2.5 rounded font-bold hover:bg-red-700 transition-colors mb-6 shadow-sm"
+          >
+            영상 보러가기
+          </a>
+        )}
+
+        <div className="border-t pt-4">
+          <div className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3">Related</div>
+          <div className="flex flex-wrap gap-2">
+            {selected.relatedPokemon.map(p => (
+              <div key={p.name} className="flex items-center gap-2 border px-2.5 py-1 rounded bg-slate-50 text-slate-600">
+                <img src={p.image} className="w-6 h-6 object-contain" alt="" />
+                <span className="text-xs font-medium">{p.name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -1,0 +1,21 @@
+import type { PokemonBiology } from '../api/biology';
+
+interface ListCardProps {
+  doc: PokemonBiology;
+  onClick: (doc: PokemonBiology) => void;
+}
+
+export default function ListCard({ doc, onClick }: ListCardProps) {
+  return (
+    <div 
+      onClick={() => onClick(doc)}
+      className="border p-4 rounded cursor-pointer hover:bg-gray-50 flex items-center gap-4 transition-colors"
+    >
+      <img src={doc.pokemonImage} alt="" className="w-16 h-16 object-contain" />
+      <div className="flex-1 min-w-0">
+        <div className="font-bold text-slate-900">{doc.pokemon}</div>
+        <div className="text-sm text-slate-500 truncate">{doc.videoTitle}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,27 @@
 @import "tailwindcss";
+
+@layer utilities {
+  .animate-in {
+    animation-duration: 300ms;
+    animation-fill-mode: both;
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  
+  .fade-in {
+    animation-name: fade-in;
+  }
+  
+  .zoom-in {
+    animation-name: zoom-in;
+  }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes zoom-in {
+  from { transform: scale(0.95); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}


### PR DESCRIPTION
## 🎯 주제
포켓몬을 생물학 관점으로 간단히 소개하고, 관련 영상을 추천해주는 **"포켓몬 생물학 추천 문서"**

## 🛠️ 주요 변경 사항
기획 문서에 정의된 방향성(복잡한 연구 리포트 시스템을 대신해 `간단한 카드 목록 + 상세 설명` 구조로 단순화)에 맞춰 다음 핵심 기능들을 구현

**1. 포켓몬 썸네일 카드 목록 구현 (`ListCard`)**
- GitHub 이슈에 단순화된 JSON 형태로 관리되는 데이터 항목들을 불러와 메인 화면 리스트로 그립니다.
- PokeAPI와 연동해 포켓몬 이름에 맞는 썸네일 이미지를 가져옵니다.
- 목록 카드에는 [기본 썸네일, 포켓몬 이름, 영상 제목]만 직관적으로 노출되도록 구성했습니다.

**2. 추천 영상 요약 (상세 보기 기입, `BiologyModal`)**
- 메인 목록에서 카드를 클릭했을 때, 해당 콘텐츠를 가볍게 읽을 수 있는 모달 뷰를 만들었습니다.
- JSON 데이터에서 파싱한 영상의 가장 중요한 핵심 질문(`primaryQuestion`)과 영상 내용 요약(`summary`)이 표시됩니다.

**3. 관련 포켓몬 묶음 보기**
- 상세 환경 한 쪽에 이 주제에 같이 등장하는 포켓몬 목록(`relatedPokemon` 배열) 시각화 기능을 구현했습니다. (예: 야돈과 함께 등장하는 셀러, 야도란의 이미지 병렬 호출)

**4. 추가 UI 작업 (인터랙션 및 시각화 반영)**

- 카드 앞/뒤 플립(Flip) 인터랙션
- 연관 포켓몬 시각화

---
<img width="439" height="117" alt="image" src="https://github.com/user-attachments/assets/19448287-a25a-403c-beae-9f4555b9aef2" />
<img width="526" height="568" alt="image" src="https://github.com/user-attachments/assets/a794ac8c-18a2-40ee-aa51-40fd519f1f9d" />

